### PR TITLE
Sks 78 leaderboard db schema

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -82,3 +82,7 @@ Linux
 Windows
 
     python -m pytest
+
+## Database queries
+
+- For inserting timestamps and dates you can use the Postgres [built-in functions](https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-CURRENT).

--- a/database/README.md
+++ b/database/README.md
@@ -30,6 +30,22 @@ To setup the database:
     python init_database.py dev
     ```
 
+## Production
+
+If changes are made to database and production database needs to be reinitialized, use the following commands
+
+1. First open the proxy tunnel to fly's postgres service
+
+    ```
+    fly proxy 5433:5432 -a <postgres-app-name>
+    ```
+
+2. Execute the .sql file against the stocking database
+
+    ```
+    psql postgres://postgres:<password>@localhost:5433/stock_king -a -f init_tables.sql
+    ```
+    
 ## Prerequisites
 
 - Installation of Postgres

--- a/database/init_tables.sql
+++ b/database/init_tables.sql
@@ -25,5 +25,6 @@ CREATE TABLE Scores(
     player_name TEXT NOT NULL,
     score INT NOT NULL,
     country TEXT,
+    gamemode TEXT,
     timestamp TIMESTAMP WITH TIME ZONE NOT NULL
 );

--- a/database/init_tables.sql
+++ b/database/init_tables.sql
@@ -5,7 +5,7 @@ CREATE TABLE ExchangeRates(
     ratio FLOAT NOT NULL,
     date DATE NOT NULL,
     PRIMARY KEY (to_currency, from_currency)
-    );
+);
 
 DROP TABLE IF EXISTS Company CASCADE;
 CREATE TABLE Company(
@@ -17,4 +17,13 @@ CREATE TABLE Company(
     date DATE NOT NULL,
     sector TEXT NOT NULL,
     website TEXT
+);
+
+DROP TABLE IF EXISTS Scores CASCADE;
+CREATE TABLE Scores(
+    sid INT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    player_name TEXT NOT NULL,
+    score INT NOT NULL,
+    country TEXT,
+    timestamp TIMESTAMP WITH TIME ZONE NOT NULL
 );


### PR DESCRIPTION
Added database schema for the table that records player score data, used in the leaderboard view. Also added instructions to reinitialize the production database for these changes and a note about how to insert timestamps in the database.