### PR TITLE
SKS-99 Backend currency conversion error fix

### DIFF
--- a/backend/flaskr/utils.py
+++ b/backend/flaskr/utils.py
@@ -438,5 +438,5 @@ def get_exchange_rate(exchange_rates, from_currency, to_currency):
              return exchange_rate["ratio"]
         elif exchange_rate["to_currency"] == from_currency and exchange_rate["from_currency"] == to_currency:
             return 1/exchange_rate["ratio"]
-    return None
+    return 1
 


### PR DESCRIPTION
get_exchange_rate is being called with (exchange_rates,USD,USD), so its trying to get the exchange rate between USD and USD, which is of course 1. The exchange rate table doesn't have a matching row, so it defaults to None. Changing the default return from None to 1 fixes the issue.