### PR TITLE
Employee count unavailable causes error in database upsert

### DIFF
--- a/backend/flaskr/utils.py
+++ b/backend/flaskr/utils.py
@@ -90,7 +90,7 @@ def process_stock_data(tickers):
                     "date": current_date,
                     "sector": ticker.info["sector"],
                     "website": ticker.info["website"],
-                    "full_time_employees": ticker.info.get("fullTimeEmployees", "Employee count unavailable")
+                    "full_time_employees": ticker.info.get("fullTimeEmployees")
                 }
             )
         except:


### PR DESCRIPTION
"Employee count unavailable" default option is a string, not an integer, therefore if it's triggered it causes database upserts to fail